### PR TITLE
Add utility Fib function to check for Link Local

### DIFF
--- a/aioexabgp/announcer/sample_announcer.json
+++ b/aioexabgp/announcer/sample_announcer.json
@@ -1,5 +1,5 @@
 {
-    "conf_version": "0.0.2",
+    "conf_version": "0.0.3",
     "advertise": {
         "interval": 5.0,
         "next_hop": "self",
@@ -28,6 +28,7 @@
     },
     "learn": {
         "allow_default": false,
+        "allow_default_ll": false,
         "fibs": [
             "Linux"
         ],

--- a/aioexabgp/tests/fibs_tests.py
+++ b/aioexabgp/tests/fibs_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3.7
 
 import unittest
-from ipaddress import ip_network
+from ipaddress import ip_address, ip_network
 
 from aioexabgp.announcer.fibs import Fib, get_fib
 
@@ -18,6 +18,18 @@ class FibsTests(unittest.TestCase):
         self.assertTrue(self.afib.is_default(ip_network("::/0")))
         self.assertFalse(self.afib.is_default(ip_network("69::/32")))
         self.assertFalse(self.afib.is_default(None))
+
+    def test_is_link_local(self) -> None:
+        # v6
+        self.assertTrue(self.afib.is_link_local(ip_address("fe80::69")))
+        self.assertTrue(self.afib.is_link_local(ip_network("fe80::/64")))
+        self.assertFalse(self.afib.is_link_local(ip_address("69::69")))
+        self.assertFalse(self.afib.is_link_local(ip_network("69::/64")))
+        # v4
+        self.assertTrue(self.afib.is_link_local(ip_address("169.254.69.69")))
+        self.assertTrue(self.afib.is_link_local(ip_network("169.254.69.0/24")))
+        self.assertFalse(self.afib.is_link_local(ip_address("6.9.6.9")))
+        self.assertFalse(self.afib.is_link_local(ip_network("6.9.6.0/24")))
 
     def test_get_fib(self) -> None:
         # Here we on purpose do not use FAKE_CONFIG

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ ptr_params = {
     "test_suite_timeout": 300,
     "required_coverage": {
         "aioexabgp/announcer/__init__.py": 45,
-        "aioexabgp/announcer/fibs.py": 45,
+        "aioexabgp/announcer/fibs.py": 50,
         "aioexabgp/announcer/healthcheck.py": 60,
         "aioexabgp/exabgpparser.py": 85,
         "aioexabgp/pipes.py": 70,


### PR DESCRIPTION
- IPv6 BGP peers send the Global and link local address
- Want the ability for potential Fib implementations to skip link local routes
- Added utility functions to calculate this

Test: Add unit test showing it working