### PR TITLE
Check routes for fibs to learn

### DIFF
--- a/aioexabgp/tests/announcer_tests.py
+++ b/aioexabgp/tests/announcer_tests.py
@@ -66,6 +66,7 @@ class AnnouncerTests(unittest.TestCase):
 
     def test_remove_internal_networks(self) -> None:
         potential_networks = [
+            FibPrefix(ip_network("6.9.6.0/24"), None, FibOperation.ADD_ROUTE),
             FibPrefix(ip_network("69::/32"), None, FibOperation.ADD_ROUTE),
             FibPrefix(ip_network("69::/64"), None, FibOperation.ADD_ROUTE),
             FibPrefix(ip_network("14:69::/64"), None, FibOperation.ADD_ROUTE),

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ ptr_params = {
         "aioexabgp/exabgpparser.py": 85,
         "aioexabgp/pipes.py": 70,
         "aioexabgp/utils.py": 100,
-        "TOTAL": 69,
+        "TOTAL": 70,
     },
     "run_flake8": True,
     "run_black": True,
@@ -24,7 +24,7 @@ ptr_params = {
 
 setup(
     name="aioexabgp",
-    version="2019.12.16",
+    version="2010.1.3",
     description=("asyncio exabgp base API client"),
     packages=["aioexabgp", "aioexabgp.announcer", "aioexabgp.tests"],
     url="http://github.com/cooperlees/aioexabgp/",


### PR DESCRIPTION
- It seems exabgp lets us know we've advertised prefixes we own
- Lets ensure they are not the summaries / subnets of summaries we know how to route to via our IGP

Test: Added test to show we filter approriately