### PR TITLE
Allow Default if Config permits

### DIFF
--- a/aioexabgp/tests/announcer_fixtures.py
+++ b/aioexabgp/tests/announcer_fixtures.py
@@ -23,7 +23,7 @@ ANNOUNCER_CONFIG = {
         },
     },
     "learn": {
-        "allow_default": False,
+        "allow_default": True,
         "fibs": ["Linux"],
         "filter_prefixes": [],
         "prefix_limit": 0,

--- a/aioexabgp/tests/announcer_tests.py
+++ b/aioexabgp/tests/announcer_tests.py
@@ -77,3 +77,11 @@ class AnnouncerTests(unittest.TestCase):
             self.aa.remove_internal_networks(potential_networks),
             [potential_networks[-1], potential_networks[-2]],
         )
+
+    def test_ensure_default_remove_internal_networks(self) -> None:
+        potential_networks = [
+            FibPrefix(ip_network("::/0"), None, FibOperation.ADD_ROUTE)
+        ]
+        self.assertEqual(
+            self.aa.remove_internal_networks(potential_networks), potential_networks
+        )


### PR DESCRIPTION
- remove_internal_networks always found ::/0 a overlap of any prefix (which I found strange)
- Add a check if default is allows that we return it to be advertised

Test: Add unit test to ensure behaviour we want happens