### PR TITLE
Add in Memory Prefix Store

### DIFF
--- a/aioexabgp/announcer/fibs.py
+++ b/aioexabgp/announcer/fibs.py
@@ -251,7 +251,6 @@ async def prefix_consumer(
             raise
         except Exception as e:
             LOG.exception(f"[prefix_consumer] Got a {type(e)} exception")
-            continue
 
 
 async def fib_operation_runner(

--- a/aioexabgp/announcer/fibs.py
+++ b/aioexabgp/announcer/fibs.py
@@ -5,7 +5,17 @@ import logging
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
 from platform import system
-from typing import Awaitable, Dict, List, NamedTuple, Optional, Sequence, Union
+from typing import (
+    Awaitable,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from aioexabgp.utils import run_cmd
 
@@ -13,6 +23,10 @@ from aioexabgp.utils import run_cmd
 IPAddress = Union[IPv4Address, IPv6Address]
 IPNetwork = Union[IPv4Network, IPv6Network]
 LOG = logging.getLogger(__name__)
+
+
+# Keep a list of learn routes to be able to re-add to FIBs
+BGP_LEARNT_PREFIXES: Dict[IPNetwork, Set[IPAddress]] = {}
 
 
 class FibOperation(Enum):
@@ -144,6 +158,56 @@ class LinuxFib(Fib):
         )
 
 
+def _update_learnt_routes(fib_operations: Sequence[FibPrefix]) -> Tuple[int, int]:
+    """ Take fib operations and keep BGP_LEARNT_PREFIXES in sync """
+    global BGP_LEARNT_PREFIXES
+    add_count = 0
+    del_count = 0
+
+    LOG.debug(
+        f"[update_learnt_rotues] Attempting to update BGP Learnt Prefixes dictionary"
+    )
+    for fib_op in fib_operations:
+        if fib_op.operation == FibOperation.ADD_ROUTE:
+            if fib_op.prefix not in BGP_LEARNT_PREFIXES:
+                if fib_op.next_hop:
+                    BGP_LEARNT_PREFIXES[fib_op.prefix] = {fib_op.next_hop}
+                else:
+                    BGP_LEARNT_PREFIXES[fib_op.prefix] = set()
+            elif fib_op.next_hop:
+                BGP_LEARNT_PREFIXES[fib_op.prefix].add(fib_op.next_hop)
+            else:
+                LOG.error(
+                    f"[update_learnt_rotues] Got a learnt route with no nethop: {fib_op}"
+                )
+                continue
+            add_count += 1
+        elif fib_op.operation == FibOperation.REMOVE_ROUTE:
+            if fib_op.prefix not in BGP_LEARNT_PREFIXES:
+                LOG.error(
+                    f"[update_learnt_rotues] {fib_op.prefix} not foud in BGP Learnt "
+                    + "Prefixes - Not deleted"
+                )
+                continue
+
+            del_ops = 0
+            if fib_op.next_hop in BGP_LEARNT_PREFIXES[fib_op.prefix]:
+                BGP_LEARNT_PREFIXES[fib_op.prefix].remove(fib_op.next_hop)
+                del_ops += 1
+
+            if not BGP_LEARNT_PREFIXES[fib_op.prefix]:
+                del BGP_LEARNT_PREFIXES[fib_op.prefix]
+                del_ops += 1
+
+            if del_ops:
+                del_count += 1
+            else:
+                LOG.error(f"[update_learnt_rotues] No deletion took place for {fib_op}")
+
+    LOG.info(f"[update_learnt_rotues] Completed {add_count} adds / {del_count} removes")
+    return (add_count, del_count)
+
+
 def get_fib(fib_name: str, config: Dict) -> Fib:
     if fib_name == "Linux":
         return LinuxFib(config)
@@ -174,6 +238,7 @@ async def prefix_consumer(
             raise
         except Exception as e:
             LOG.exception(f"[prefix_consumer] Got a {type(e)} exception")
+            continue
 
 
 async def fib_operation_runner(
@@ -233,3 +298,5 @@ async def fib_operation_runner(
                 "[fib_operation_runner] There was a FIB operation failure. "
                 + " Please investigate!"
             )
+        else:
+            _update_learnt_routes(fib_operations)

--- a/aioexabgp/tests/fibs_tests.py
+++ b/aioexabgp/tests/fibs_tests.py
@@ -90,3 +90,17 @@ class FibsTests(unittest.TestCase):
         self.assertEqual(adds, 0)
         self.assertEqual(dels, 0)
         self.assertFalse(BGP_LEARNT_PREFIXES)
+
+        # Add and remove all
+        adds, dels = _update_learnt_routes(gen_fib_operations(FibOperation.ADD_ROUTE))
+        adds, dels = _update_learnt_routes(
+            [
+                FibPrefix(
+                    ip_network("69::/64"),
+                    ip_address("2469::1"),
+                    FibOperation.REMOVE_ALL_ROUTES,
+                )
+            ]
+        )
+        self.assertEqual(dels, 2)
+        self.assertFalse(BGP_LEARNT_PREFIXES)

--- a/aioexabgp/tests/fibs_tests.py
+++ b/aioexabgp/tests/fibs_tests.py
@@ -1,13 +1,38 @@
 #!/usr/bin/env python3.7
 
 import unittest
+from unittest.mock import patch
 from ipaddress import ip_address, ip_network
+from typing import List, Sequence
 
-from aioexabgp.announcer.fibs import Fib, get_fib
+from aioexabgp.announcer.fibs import (
+    BGP_LEARNT_PREFIXES,
+    Fib,
+    FibOperation,
+    FibPrefix,
+    _update_learnt_routes,
+    get_fib,
+)
 
 
 # TODO: Get a better test config + test more of the Fib class
 FAKE_CONFIG = {"learn": {"allow_default": True, "prefix_limit": 10}}
+NETWORK_PREFIXES = (ip_network("::/0"), ip_network("69::/64"))
+
+
+def gen_fib_operations(
+    operation: FibOperation, errors: bool = False
+) -> Sequence[FibPrefix]:
+    fib_ops: List[FibPrefix] = []
+    next_hop = ip_address("2469::1")
+
+    for prefix in NETWORK_PREFIXES:
+        if errors:
+            fib_ops.append(FibPrefix(prefix, None, operation))
+            continue
+        fib_ops.append(FibPrefix(prefix, next_hop, operation))
+
+    return fib_ops
 
 
 class FibsTests(unittest.TestCase):
@@ -39,3 +64,29 @@ class FibsTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             get_fib("JunOS", bs_config)
+
+    def test_update_learnt_routes(self) -> None:
+        # Make sure dict is empty
+        self.assertFalse(BGP_LEARNT_PREFIXES)
+        # Add some prefixes
+        adds, dels = _update_learnt_routes(gen_fib_operations(FibOperation.ADD_ROUTE))
+        self.assertEqual(adds, 2)
+        self.assertEqual(dels, 0)
+        self.assertTrue(BGP_LEARNT_PREFIXES)
+        # Delete some prefixes
+        adds, dels = _update_learnt_routes(
+            gen_fib_operations(FibOperation.REMOVE_ROUTE)
+        )
+        self.assertEqual(adds, 0)
+        self.assertEqual(dels, 2)
+        # Make sure dict is empty again
+        self.assertFalse(BGP_LEARNT_PREFIXES)
+
+        with patch("aioexabgp.announcer.fibs.LOG.error") as mocked_err_log:
+            adds, dels = _update_learnt_routes(
+                gen_fib_operations(FibOperation.REMOVE_ROUTE, errors=True)
+            )
+            self.assertEqual(mocked_err_log.call_count, 2)
+        self.assertEqual(adds, 0)
+        self.assertEqual(dels, 0)
+        self.assertFalse(BGP_LEARNT_PREFIXES)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ ptr_params = {
         "aioexabgp/exabgpparser.py": 85,
         "aioexabgp/pipes.py": 70,
         "aioexabgp/utils.py": 100,
-        "TOTAL": 70,
     },
     "run_flake8": True,
     "run_black": True,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ ptr_params = {
     "test_suite_timeout": 300,
     "required_coverage": {
         "aioexabgp/announcer/__init__.py": 50,
-        "aioexabgp/announcer/fibs.py": 50,
+        "aioexabgp/announcer/fibs.py": 55,
         "aioexabgp/announcer/healthcheck.py": 60,
         "aioexabgp/exabgpparser.py": 85,
         "aioexabgp/pipes.py": 70,
@@ -24,7 +24,7 @@ ptr_params = {
 
 setup(
     name="aioexabgp",
-    version="2020.2.24",
+    version="2020.4.9",
     description=("asyncio exabgp base API client"),
     packages=["aioexabgp", "aioexabgp.announcer", "aioexabgp.tests"],
     url="http://github.com/cooperlees/aioexabgp/",


### PR DESCRIPTION
- Add a globally accessible dictionary to know all the current BGP learnt prefixes
- This could be used for prefix validation and repairs in FIBs if the FIB daemon crashes etc.

Test: Add unittests showing expected add, delete and error behavior