### PR TITLE
Add Direction to ExaBGP JSON update parsing

### DIFF
--- a/aioexabgp/exabgpparser.py
+++ b/aioexabgp/exabgpparser.py
@@ -62,9 +62,16 @@ class ExaBGPParser:
 
         return []
 
-    async def parse_update(
-        self, exa_json: Dict, wanted_families: Sequence[str] = DEFAULT_FAMALIES
+    async def parse_update(  # noqa: C901
+        self,
+        exa_json: Dict,
+        wanted_families: Sequence[str] = DEFAULT_FAMALIES,
+        direction_wanted: str = "receive",
     ) -> List[FibPrefix]:
+        # Ensure this update is the direction we want - Default to receive
+        if exa_json["neighbor"]["direction"] != direction_wanted:
+            return []
+
         fib_prefixes: List[FibPrefix] = []
         try:
             update_json = exa_json["neighbor"]["message"]["update"]

--- a/aioexabgp/tests/exabgpparser_fixtures.py
+++ b/aioexabgp/tests/exabgpparser_fixtures.py
@@ -136,3 +136,28 @@ EXPECTED_WITHDRAW_REPONSE = [
         ip_network("70::/32"), ip_address("fc00:0:0:69::2"), FibOperation.REMOVE_ROUTE
     )
 ]
+
+EXABGP_UPDATE_SEND_JSON = {
+    "exabgp": "4.0.1",
+    "time": 1562873630.5337727,
+    "host": "some.router.com",
+    "pid": 4734,
+    "ppid": 4733,
+    "counter": 69,
+    "type": "update",
+    "neighbor": {
+        "address": {"local": "fc00:0:0:69::2", "peer": "fc00:0:0:69::1"},
+        "asn": {"local": 65069, "peer": 65070},
+        "direction": "send",
+        "message": {
+            "update": {
+                "attribute": {
+                    "origin": "igp",
+                    "as-path": [65070],
+                    "confederation-path": [],
+                },
+                "announce": {"ipv6 unicast": {"fc00:0:0:69::2": [{"nlri": "70::/32"}]}},
+            }
+        },
+    },
+}

--- a/aioexabgp/tests/exabgpparser_tests.py
+++ b/aioexabgp/tests/exabgpparser_tests.py
@@ -14,6 +14,7 @@ from aioexabgp.tests.exabgpparser_fixtures import (
     EXPECTED_UP_RESPONSE,
     EXABGP_UPDATE_JSON,
     EXPECTED_UPDATE_REPONSE,
+    EXABGP_UPDATE_SEND_JSON,
     EXABGP_WITHDRAW_JSON,
     EXPECTED_WITHDRAW_REPONSE,
     FAKE_HEALTHY_PREFIXES,
@@ -61,4 +62,9 @@ class ExabgpParserTests(unittest.TestCase):
         self.assertEqual(
             EXPECTED_WITHDRAW_REPONSE,
             self.loop.run_until_complete(self.ebp.parse(EXABGP_WITHDRAW_JSON)),
+        )
+
+    def test_parse_update_direction_send(self) -> None:
+        self.assertEqual(
+            [], self.loop.run_until_complete(self.ebp.parse(EXABGP_UPDATE_SEND_JSON)),
         )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ ptr_params = {
         "aioexabgp/announcer/__init__.py": 50,
         "aioexabgp/announcer/fibs.py": 55,
         "aioexabgp/announcer/healthcheck.py": 60,
-        "aioexabgp/exabgpparser.py": 85,
+        "aioexabgp/exabgpparser.py": 90,
         "aioexabgp/pipes.py": 70,
         "aioexabgp/utils.py": 100,
     },
@@ -23,7 +23,7 @@ ptr_params = {
 
 setup(
     name="aioexabgp",
-    version="2020.4.9",
+    version="2020.4.11",
     description=("asyncio exabgp base API client"),
     packages=["aioexabgp", "aioexabgp.announcer", "aioexabgp.tests"],
     url="http://github.com/cooperlees/aioexabgp/",


### PR DESCRIPTION
- By default we only care about received updates for parsing
- Change function to limit to receive by default only

Test: Add a unittest to show it working