### PR TITLE
Rename allow_default_ll to allow_ll_nexthop + Super Class support

### DIFF
--- a/aioexabgp/announcer/sample_announcer.json
+++ b/aioexabgp/announcer/sample_announcer.json
@@ -1,5 +1,5 @@
 {
-    "conf_version": "0.0.3",
+    "conf_version": "0.0.4",
     "advertise": {
         "interval": 5.0,
         "next_hop": "self",
@@ -29,7 +29,7 @@
     },
     "learn": {
         "allow_default": false,
-        "allow_default_ll": false,
+        "allow_ll_nexthop": false,
         "fibs": [
             "Linux"
         ],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ ptr_params = {
     "test_suite_timeout": 300,
     "required_coverage": {
         "aioexabgp/announcer/__init__.py": 50,
-        "aioexabgp/announcer/fibs.py": 55,
+        "aioexabgp/announcer/fibs.py": 59,
         "aioexabgp/announcer/healthcheck.py": 60,
         "aioexabgp/exabgpparser.py": 90,
         "aioexabgp/pipes.py": 70,
@@ -23,7 +23,7 @@ ptr_params = {
 
 setup(
     name="aioexabgp",
-    version="2020.4.11",
+    version="2020.5.13",
     description=("asyncio exabgp base API client"),
     packages=["aioexabgp", "aioexabgp.announcer", "aioexabgp.tests"],
     url="http://github.com/cooperlees/aioexabgp/",


### PR DESCRIPTION
- Remove from a consumer tool the logic of allow or disallowing link local nethops being added to fibs

Test:
- Add unittests